### PR TITLE
[BOJ 11724] 연결 요소의 개수 - Roel

### DIFF
--- a/Roel/BOJ/11724.py
+++ b/Roel/BOJ/11724.py
@@ -1,0 +1,29 @@
+import sys
+input = sys.stdin.readline
+N, M = map(int, input().split())
+
+graph = [[] for _ in range(N+1)]
+
+for _ in range(M):
+    a, b = map(int, input().split())
+    graph[a].append(b)
+    graph[b].append(a)
+
+
+visited = [False] * (N+1)
+cnt = 0
+
+for i in range(1, N+1):
+    if not visited[i]:
+        cnt += 1
+        stack = [i]
+        visited[i] = True
+
+        while stack:
+            node = stack.pop()
+            for neighbor in graph[node]:
+                if not visited[neighbor]:
+                    visited[neighbor] = True
+                    stack.append(neighbor)
+
+print(cnt)


### PR DESCRIPTION
## 📌 관련 이슈

closes #15 

---

## ✍️ 풀이 요약

**언어:** Python  
**시간 복잡도:** -  
**공간 복잡도:** -  

### 접근 방법

그래프를 인접 리스트로 구성한 뒤, 모든 노드를 순회하며 방문하지 않은 노드를 시작점으로 스택 기반 DFS를 수행했습니다. DFS가 한 번 실행될 때마다 연결 요소 카운트를 증가시켜 최종 연결 요소 개수를 구했습니다.

---

## 💡 어려웠던 점 / 배운 점

- BOJ 2606 바이러스 문제와 유사하지만 약간 다른 유형으로, 비슷한 유형의 문제를 반복해서 풀어보는 게 도움이 될 것 같습니다. 같은 유형 추가 문제도 추천드려요!