### PR TITLE
[BOJ 34875] 자벌레 세기 - Roel

### DIFF
--- a/Roel/BOJ/34875.py
+++ b/Roel/BOJ/34875.py
@@ -1,0 +1,25 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+
+deg = [0]*(N+1)
+edges = []
+
+for _ in range(N-1):
+    u, v = map(int, input().split())
+    edges.append((u, v))
+    deg[u] += 1
+    deg[v] += 1
+
+def comb2(x):
+    if x < 2:
+        return 0
+    return x*(x-1)//2
+
+ans = 0
+
+for u, v in edges:
+    ans += comb2(deg[u]-1) * comb2(deg[v]-1)
+
+print(ans)


### PR DESCRIPTION
## 📌 관련 이슈

Closes #4

---

## ✍️ 풀이 요약

**언어:** Python  
**시간 복잡도:** -  
**공간 복잡도:** -  

### 접근 방법

- 각 간선 `(u, v)`를 리스트에 저장하고, 각 노드의 차수(degree)를 계산
- 각 간선에 대해 양 끝 노드 `u`, `v`에서 해당 간선을 제외한 나머지 간선의 수로 `C(deg-1, 2)` 계산
- 두 값을 곱해 해당 간선을 몸통으로 하는 자벌레의 수를 구하고 `ans`에 누적
- `deg-1`을 사용한 이유: 몸통이 되는 간선 자체는 제외해야 하기 때문

---

## 💡 어려웠던 점 / 배운 점

- 특별히 어려웠던 점과 새롭게 배운 점은 없었습니다.