### PR TITLE
[BOJ/11726]/2xn 타일링 - Yuky

### DIFF
--- a/Yuky/BOJ/11726.py
+++ b/Yuky/BOJ/11726.py
@@ -1,0 +1,18 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+
+if n == 1:
+    print(1)
+else:
+    dp = [0] * (n+1)
+    dp[1] = 1
+    dp[2] = 2
+
+    for i in range(3, n+1):
+        # 세로타일 1개 추가: i - 1
+        # 가로타일 2개 추가: i - 2
+        dp[i] = (dp[i-1] + dp[i-2])%10007
+
+    print(dp[n])


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 풀이한 문제 이슈 링크 -->
closes #

---

## ✍️ 풀이 요약

**언어:** Python
**시간 복잡도:** O(N)
**공간 복잡도:**  O(N)

### 접근 방법

<!-- 어떤 알고리즘/자료구조를 사용했는지, 핵심 아이디어를 간단히 설명해 주세요 -->
dp
---

## 💡 어려웠던 점 / 배운 점 (선택)

<!-- 풀면서 막혔던 부분이나 새롭게 알게 된 내용을 공유해 주세요 -->
1. dp[n]에서 n 이전의 n - k, k 조합을 모두 생각하려고하다가 처음에 막힘
n - 1, n - 2 타일 세로 1개, 가로 2개 조합과 나머지로 생각해야함.
2. 런타임 에러 계속 나서 뭐지 싶었음. 처음엔 큰 수를 10007로 마지막에 한번만 나눠줘서 그런가 싶었음.
근데 처음에 dp[1], dp[2] initialize 할때 n = 1일때의 경우를 생각 못해줌.
앞으로 기초적인 경우의 수도 까먹지 말고 고려해야겠음.
---

## 🔍 리뷰 요청 사항 (선택)

<!-- 특별히 피드백 받고 싶은 부분이 있으면 적어주세요 -->
