### PR TITLE
[BOJ 11054] 가장 긴 바이토닉 부분 수열 - Roel

### DIFF
--- a/Roel/BOJ/11054.py
+++ b/Roel/BOJ/11054.py
@@ -1,0 +1,24 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+A = list(map(int, input().split()))
+
+inc = [1] * N
+dec = [1] * N
+
+for i in range(N):
+    for j in range(i):
+        if A[j] < A[i]:
+            inc[i] = max(inc[i], inc[j] + 1)
+
+for i in range(N - 1, -1, -1):
+    for j in range(N - 1, i, -1):
+        if A[j] < A[i]:
+            dec[i] = max(dec[i], dec[j] + 1)
+
+answer = 0
+for i in range(N):
+    answer = max(answer, inc[i] + dec[i] - 1)
+
+print(answer)


### PR DESCRIPTION
## 📌 관련 이슈

closes #61 

---

## ✍️ 풀이 요약

**언어:** Python
**시간 복잡도:** O(N²)
**공간 복잡도:** O(N)

### 접근 방법

- LIS(가장 긴 증가 부분 수열)를 두 방향으로 계산하여 결합
- `inc[i]`: 왼쪽에서 i까지의 LIS 길이 (증가하는 방향)
- `dec[i]`: 오른쪽에서 i까지의 LIS 길이 (감소하는 방향)
- 각 인덱스 i를 바이토닉 수열의 꼭짓점으로 보고 `inc[i] + dec[i] - 1`의 최댓값이 정답

---

## 💡 어려웠던 점 / 배운 점 (선택)

- 바이토닉 수열을 LIS 두 번으로 분리해서 풀 수 있다는 아이디어가 핵심이었습니다
- 오른쪽에서의 LIS는 역방향으로 순회하면 동일하게 구할 수 있음을 배웠습니다