### PR TITLE
[BOJ 11727] 2×n 타일링 2 - Roel

### DIFF
--- a/Roel/BOJ/11727.py
+++ b/Roel/BOJ/11727.py
@@ -1,0 +1,18 @@
+import sys
+
+input = sys.stdin.readline
+
+N = int(input())
+
+dp = [0] * (N + 1)
+
+dp[1] = 1
+if N >= 2: dp[2] = 3
+
+def f(n):
+    if dp[n]:
+        return dp[n]
+    dp[n] = (f(n - 1) + 2*f(n - 2)) % 10007
+    return dp[n] % 10007
+
+print(f(N))


### PR DESCRIPTION
## 📌 관련 이슈

closes #44

---

## ✍️ 풀이 요약

**언어:** Python
**시간 복잡도:** O(N)
**공간 복잡도:** O(N)

### 접근 방법

- `dp[n] = dp[n-1] + 2*dp[n-2]` 점화식을 메모이제이션 방식으로 구현
- 마지막 열에 1×2 타일 세로 1개를 놓는 경우 → `dp[n-1]`
- 마지막 두 열에 2×1 타일 가로 2개 또는 2×2 타일 1개를 놓는 경우 → `2 * dp[n-2]`
- 11726번과 달리 2×2 타일이 추가되어 `dp[n-2]`에 ×2를 적용
- 결과값은 10007로 나눈 나머지 출력

---

## 💡 어려웠던 점 / 배운 점 (선택)

- 11726번 타일링과 점화식 구조는 같지만 2×2 타일 경우의 수가 추가되어 계수가 달라지는 점을 파악했습니다